### PR TITLE
Fix package install with Raspbian Buster

### DIFF
--- a/en/step_5.md
+++ b/en/step_5.md
@@ -5,7 +5,7 @@ MySQL (pronounced *My Sequel* or *My S-Q-L*) is a popular database engine. Like 
 Install the MySQL Server and PHP-MySQL packages by entering the following command into the terminal window:
 
 ```bash
-sudo apt-get install mysql-server php-mysql -y
+sudo apt-get install mariadb-server-10.0 php-mysql -y
 ```
 
 Now restart Apache:


### PR DESCRIPTION
Hello.

The `mysql-server` package doesn't exist in Raspbian Buster. It is replaced by the `mariadb-server-10.0` package. When you install it in the Step 5, you get an error.

Thanks